### PR TITLE
Add .well-known configuration for matrix clients

### DIFF
--- a/public/.well-known/matrix/client
+++ b/public/.well-known/matrix/client
@@ -1,0 +1,1 @@
+{"m.homeserver": {"base_url": "https://synapse.law-orga.de"}}


### PR DESCRIPTION
This configuration is used by clients when the url `law-orga.de` is given as the homeserver url to connect to the correct server. The specification can be found [here](https://spec.matrix.org/v1.3/client-server-api/#well-known-uri).