### PR TITLE
Redirect to previous page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,7 +56,7 @@ import BannerList from "./components/BannerList.vue";
 import { getCookie } from "./utils/cookie";
 
 if (!getCookie("csrftoken")) {
-  const redirect = `${window.location.origin}/user/register`;
+  const redirect = `${window.location.href}`;
   const redirectEncoded = encodeURIComponent(redirect);
   const backend = import.meta.env.VITE_AUTH_URL;
   const cookieSetLink = `${backend}/redirect/?next=${redirectEncoded}`;


### PR DESCRIPTION
When no csrftoken is available (first time opening the page) a new csrftoken is renerated from the backend and a redirect to the user registration is performed.
Insted the redirect after issuing the csrftoken should be to the page the user wanted to see originally