### PR TITLE
Update NavigationSidebar.vue

### DIFF
--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -44,7 +44,6 @@ const isNavigationItemActive = (item: NavigationItem): boolean => {
   return currentPath.startsWith(itemPath);
 };
 
-// Compute initial from the last word of the user's name
 const lastNameInitial = computed(() => {
   const fullName = userStore.user?.name || "";
   const lastName = fullName.split(" ").slice(-1)[0] || "";
@@ -106,7 +105,6 @@ const lastNameInitial = computed(() => {
           <CircleLoader v-show="!userStore.loaded" class="text-white" />
         </div>
 
-        <!-- Collapsed account initial field -->
         <div
           v-show="!expanded"
           class="flex items-center justify-center h-14 border-b border-white/20 bg-lorgablue text-white font-bold text-lg"
@@ -115,7 +113,7 @@ const lastNameInitial = computed(() => {
         </div>
 
         <div class="flex flex-col justify-between bg-white grow">
-          <!-- Navigation items container with consistent spacing -->
+         
           <nav
             class="flex-1 pb-2 bg-white"
             :class="{

--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -47,7 +47,7 @@ const isNavigationItemActive = (item: NavigationItem): boolean => {
 const lastNameInitial = computed(() => {
   const fullName = userStore.user?.name || "";
   const lastName = fullName.split(" ").slice(-1)[0] || "";
-  return lastWord.charAt(0).toUpperCase();
+  return lastName.charAt(0).toUpperCase();
 });
 </script>
 
@@ -73,7 +73,7 @@ const lastNameInitial = computed(() => {
         >
           <router-link
             :to="{ name: 'start' }"
-            class="flex items-center h-10 px-4 -ml-2 space-x-2 rounded hover:bg-gray-50/10"
+            class="flex items-center h-10 px-2 -ml-2 space-x-2 rounded hover:bg-gray-50/10"
           >
             <div class="-ml-2">
               <LogoWhite />
@@ -107,7 +107,7 @@ const lastNameInitial = computed(() => {
 
         <div
           v-show="!expanded"
-          class="flex items-center justify-center h-14 border-b border-white/20 bg-lorgablue text-white font-bold text-lg"
+          class="px-4 py-3 flex items-center justify-center border-b border-white/20 bg-lorgablue text-white font-bold text-lg"
         >
           {{ lastNameInitial }}
         </div>
@@ -118,7 +118,7 @@ const lastNameInitial = computed(() => {
             class="flex-1 pb-2 bg-white"
             :class="{
               'space-y-3 pt-3': !expanded,
-              'space-y-1 px-2 pt-2': expanded,
+              'space-y-1 px-2 pt-3': expanded,
             }"
           >
             <template v-for="item in navigationItems" :key="item.label">

--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -47,7 +47,7 @@ const isNavigationItemActive = (item: NavigationItem): boolean => {
 // Compute initial from the last word of the user's name
 const lastNameInitial = computed(() => {
   const fullName = userStore.user?.name || "";
-  const lastWord = fullName.split(" ").slice(-1)[0] || "";
+  const lastName = fullName.split(" ").slice(-1)[0] || "";
   return lastWord.charAt(0).toUpperCase();
 });
 </script>

--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -94,7 +94,7 @@ const lastNameInitial = computed(() => {
         </div>
         <div
           v-show="expanded"
-          class="px-4 py-3 text-white border-b border-white/20 bg-lorgablue"
+          class="px-4 py-3 text-white border-b border-white/20 "
         >
           <div v-show="userStore.loaded">
             <div class="truncate">

--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -4,7 +4,7 @@ import useNavigationItems, {
   NavigationItem,
 } from "@/composables/useNavigationItems";
 import { useUserStore } from "@/store/user";
-import { ref, watch } from "vue";
+import { ref, watch, computed } from "vue";
 import { RouteLocationRaw, useRoute, useRouter } from "vue-router";
 import LogoWhite from "./LogoWhite.vue";
 import { CircleLoader } from "lorga-ui";
@@ -43,6 +43,13 @@ const isNavigationItemActive = (item: NavigationItem): boolean => {
   const currentPath = route.path;
   return currentPath.startsWith(itemPath);
 };
+
+// Compute initial from the last word of the user's name
+const lastNameInitial = computed(() => {
+  const fullName = userStore.user?.name || "";
+  const lastWord = fullName.split(" ").slice(-1)[0] || "";
+  return lastWord.charAt(0).toUpperCase();
+});
 </script>
 
 <template>
@@ -88,7 +95,7 @@ const isNavigationItemActive = (item: NavigationItem): boolean => {
         </div>
         <div
           v-show="expanded"
-          class="px-4 py-3 text-white border-b border-white/20"
+          class="px-4 py-3 text-white border-b border-white/20 bg-lorgablue"
         >
           <div v-show="userStore.loaded">
             <div class="truncate">
@@ -99,7 +106,16 @@ const isNavigationItemActive = (item: NavigationItem): boolean => {
           <CircleLoader v-show="!userStore.loaded" class="text-white" />
         </div>
 
+        <!-- Collapsed account initial field -->
+        <div
+          v-show="!expanded"
+          class="flex items-center justify-center h-14 border-b border-white/20 bg-lorgablue text-white font-bold text-lg"
+        >
+          {{ lastNameInitial }}
+        </div>
+
         <div class="flex flex-col justify-between bg-white grow">
+          <!-- Navigation items container with consistent spacing -->
           <nav
             class="flex-1 pb-2 bg-white"
             :class="{

--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -56,8 +56,8 @@ const lastNameInitial = computed(() => {
     <div class="flex flex-col" :class="{ 'w-64': expanded, 'w-14': !expanded }">
       <div class="flex flex-col overflow-y-auto grow bg-formcolor">
 
-        <!-- Row 1: Hamburger — fixed h-16 on both sides -->
-        <div class="flex items-center h-16 border-b shrink-0 border-white/20">
+       
+        <div class="flex items-center h-20 border-b shrink-0 border-white/20">
           <button
             class="flex items-center justify-center w-10 h-10 border border-transparent rounded cursor-pointer focus:outline-none hover:bg-gray-50/10"
             :class="{ 'mx-auto': !expanded, 'ml-2 mr-2': expanded }"
@@ -67,7 +67,7 @@ const lastNameInitial = computed(() => {
           </button>
         </div>
 
-        <!-- Row 2: Logo — fixed h-14 on both sides -->
+       
         <div class="flex items-center h-14 border-b shrink-0 border-white/20"
           :class="{ 'px-4': expanded }">
           <router-link
@@ -82,7 +82,6 @@ const lastNameInitial = computed(() => {
           </router-link>
         </div>
 
-        <!-- Row 3: User info — fixed h-16 on both sides -->
         <div class="flex items-center h-16 border-b shrink-0 border-white/20"
           :class="{ 'px-4': expanded, 'justify-center': !expanded }">
           <template v-if="expanded">

--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -55,10 +55,9 @@ const lastNameInitial = computed(() => {
   <div class="hidden md:flex md:shrink-0 print:hidden">
     <div class="flex flex-col" :class="{ 'w-64': expanded, 'w-14': !expanded }">
       <div class="flex flex-col overflow-y-auto grow bg-formcolor">
-        <div
-          class="flex items-center h-16 border-b shrink-0 border-white/20"
-          :class="{ 'border-r': !expanded }"
-        >
+
+        <!-- Row 1: Hamburger — fixed h-16 on both sides -->
+        <div class="flex items-center h-16 border-b shrink-0 border-white/20">
           <button
             class="flex items-center justify-center w-10 h-10 border border-transparent rounded cursor-pointer focus:outline-none hover:bg-gray-50/10"
             :class="{ 'mx-auto': !expanded, 'ml-2 mr-2': expanded }"
@@ -67,53 +66,42 @@ const lastNameInitial = computed(() => {
             <Bars3CenterLeftIcon class="w-6 h-6 text-white" />
           </button>
         </div>
-        <div
-          v-show="expanded"
-          class="flex items-center px-4 py-1 border-b h-14 border-white/20"
-        >
+
+        <!-- Row 2: Logo — fixed h-14 on both sides -->
+        <div class="flex items-center h-14 border-b shrink-0 border-white/20"
+          :class="{ 'px-4': expanded }">
           <router-link
             :to="{ name: 'start' }"
-            class="flex items-center h-10 px-2 -ml-2 space-x-2 rounded hover:bg-gray-50/10"
+            class="flex items-center h-10 px-2 rounded hover:bg-gray-50/10"
+            :class="{ 'mx-auto': !expanded, '-ml-2 space-x-2': expanded }"
           >
-            <div class="-ml-2">
+            <div :class="{ '-ml-2': expanded }">
               <LogoWhite />
             </div>
-            <h1 class="text-2xl font-bold text-white">Law&Orga</h1>
+            <h1 v-show="expanded" class="text-2xl font-bold text-white">Law&Orga</h1>
           </router-link>
-        </div>
-        <div
-          v-show="!expanded"
-          class="flex items-center border-b h-14 border-white/20"
-        >
-          <router-link
-            :to="{ name: 'start' }"
-            class="flex items-center justify-center w-10 h-10 mx-auto rounded hover:bg-gray-50/10"
-          >
-            <LogoWhite />
-          </router-link>
-        </div>
-        <div
-          v-show="expanded"
-          class="px-4 py-3 text-white border-b border-white/20 "
-        >
-          <div v-show="userStore.loaded">
-            <div class="truncate">
-              {{ userStore.org?.name }}: {{ userStore.user?.name }}
-            </div>
-            <div class="truncate">{{ userStore.user?.email }}</div>
-          </div>
-          <CircleLoader v-show="!userStore.loaded" class="text-white" />
         </div>
 
-        <div
-          v-show="!expanded"
-          class="px-4 py-3 flex items-center justify-center border-b border-white/20 bg-lorgablue text-white font-bold text-lg"
-        >
-          {{ lastNameInitial }}
+        <!-- Row 3: User info — fixed h-16 on both sides -->
+        <div class="flex items-center h-16 border-b shrink-0 border-white/20"
+          :class="{ 'px-4': expanded, 'justify-center': !expanded }">
+          <template v-if="expanded">
+            <div v-show="userStore.loaded" class="w-full overflow-hidden">
+              <div class="truncate text-white">
+                {{ userStore.org?.name }}: {{ userStore.user?.name }}
+              </div>
+              <div class="truncate text-white text-sm">{{ userStore.user?.email }}</div>
+            </div>
+            <CircleLoader v-show="!userStore.loaded" class="text-white" />
+          </template>
+          <template v-else>
+            <div class="flex items-center justify-center w-10 h-10 rounded bg-lorgablue text-white font-bold text-lg">
+              {{ lastNameInitial }}
+            </div>
+          </template>
         </div>
 
         <div class="flex flex-col justify-between bg-white grow">
-         
           <nav
             class="flex-1 pb-2 bg-white"
             :class="{
@@ -124,7 +112,6 @@ const lastNameInitial = computed(() => {
             <template v-for="item in navigationItems" :key="item.label">
               <div v-if="item.divider">
                 <div
-                  class=""
                   :class="{
                     'w-full py-4': expanded,
                     'w-10 py-0.5 mx-auto': !expanded,
@@ -145,8 +132,7 @@ const lastNameInitial = computed(() => {
                 v-bind="item.attrs"
                 class="relative flex items-center justify-between py-2 pl-2 text-sm font-medium text-gray-600 rounded-md group hover:bg-gray-50 hover:text-gray-900"
                 :class="{
-                  'text-gray-700 bg-gray-100! hover:bg-gray-100':
-                    isNavigationItemActive(item),
+                  'text-gray-700 bg-gray-100! hover:bg-gray-100': isNavigationItemActive(item),
                   'pb-5.5!': !expanded && item.is === 'a',
                   'w-10 pr-2 mx-auto': !expanded,
                   'pr-3': expanded,
@@ -185,11 +171,7 @@ const lastNameInitial = computed(() => {
           >
             <figure class="mb-3">
               <figcaption class="mb-1 text-gray-500">A project of</figcaption>
-              <a
-                href="https://rlc-deutschland.de/"
-                rel="noopener"
-                target="_blank"
-              >
+              <a href="https://rlc-deutschland.de/" rel="noopener" target="_blank">
                 <img
                   src="/rlcd.png"
                   alt="RLC Deutschland"
@@ -199,11 +181,7 @@ const lastNameInitial = computed(() => {
             </figure>
             <figure>
               <figcaption class="mb-1 text-gray-500">supported by</figcaption>
-              <a
-                href="https://www.cms-stiftung.de/"
-                rel="noopener"
-                target="_blank"
-              >
+              <a href="https://www.cms-stiftung.de/" rel="noopener" target="_blank">
                 <img
                   src="/sponsor-cms.jpg"
                   alt="CMS Stiftung"


### PR DESCRIPTION
### Short Description

Issue #514


### Proposed Changes
**File:** `src/components/NavigationSidebar.vue`

### 1. Make navigation item spacing consistent

Ensure that all navigation icons have the **same amount of white space** around them in both expanded and collapsed states:

```html
<!-- Navigation items container with consistent spacing -->
<nav class="flex-1 pt-2" :class="{ 'space-y-1 px-2': expanded, 'space-y-3 pt-3': !expanded }">
  <!-- navigation items here -->
</nav>
```

 ### 2.Add account initial field to the collapsed sidebar

Add a new field at the top of the collapsed sidebar using the same background color as the expanded account area (`lorgablue`).
This field should display the **capitalized first letter of the last word of the user’s name**.

```ts
// Compute initial from the last word of the user's name
const lastNameInitial = computed(() => {
  const fullName = userStore.user?.name || "";
  const lastWord = fullName.split(" ").slice(-1)[0] || "";
  return lastWord.charAt(0).toUpperCase();
});
```

```html
<!-- Collapsed account initial field -->
<div
  v-show="!expanded"
  class="flex items-center justify-center h-14 border-b border-white/20 bg-lorgablue text-white font-bold text-lg"
>
  {{ lastNameInitial }}
</div>
```




