### PR TITLE
575: Marking inactivity in the admin users view

### DIFF
--- a/src/components/ActivityBadge.vue
+++ b/src/components/ActivityBadge.vue
@@ -1,0 +1,26 @@
+<script lang="ts" setup>
+import type { ActivityState } from "@/features/admin/api/useProfiles";
+
+defineProps<{ state: ActivityState }>();
+
+const config: Record<ActivityState, { label: string; classes: string }> = {
+  green: { label: "Aktiv (3 Mo.)", classes: "bg-green-100 text-green-800" },
+  yellow: { label: "Aktiv (6 Mo.)", classes: "bg-yellow-100 text-yellow-800" },
+  orange: {
+    label: "Eingeloggt (6 Mo.)",
+    classes: "bg-orange-100 text-orange-800",
+  },
+  red: { label: "Inaktiv (12+ Mo.)", classes: "bg-red-100 text-red-800" },
+};
+</script>
+
+<template>
+  <span
+    :class="[
+      'inline-flex items-center px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap',
+      config[state].classes,
+    ]"
+  >
+    {{ config[state].label }}
+  </span>
+</template>

--- a/src/components/ActivityBadge.vue
+++ b/src/components/ActivityBadge.vue
@@ -4,13 +4,13 @@ import type { ActivityState } from "@/features/admin/api/useProfiles";
 defineProps<{ state: ActivityState }>();
 
 const config: Record<ActivityState, { label: string; classes: string }> = {
-  green: { label: "Aktiv (3 Mo.)", classes: "bg-green-100 text-green-800" },
-  yellow: { label: "Aktiv (6 Mo.)", classes: "bg-yellow-100 text-yellow-800" },
+  green: { label: "Active (3 mo.)", classes: "bg-green-100 text-green-800" },
+  yellow: { label: "Active (6 mo.)", classes: "bg-yellow-100 text-yellow-800" },
   orange: {
-    label: "Eingeloggt (6 Mo.)",
+    label: "Logged in (6 mo.)",
     classes: "bg-orange-100 text-orange-800",
   },
-  red: { label: "Inaktiv (12+ Mo.)", classes: "bg-red-100 text-red-800" },
+  red: { label: "Inactive (12+ mo.)", classes: "bg-red-100 text-red-800" },
 };
 </script>
 

--- a/src/features/admin/api/useProfiles.ts
+++ b/src/features/admin/api/useProfiles.ts
@@ -1,6 +1,9 @@
 import { computed, ref, Ref } from "vue";
 import useGet2 from "@/composables/useGet2";
 
+export type ActivityState = "green" | "yellow" | "orange" | "red";
+
+
 export interface OrgUserSmall {
   id: number;
   user_id: number;
@@ -13,6 +16,7 @@ export interface OrgUserSmall {
   locked: boolean;
   is_active: boolean;
   qualifications: string[];
+  activity_state: ActivityState;
 }
 
 export function useProfiles() {

--- a/src/features/admin/api/useProfiles.ts
+++ b/src/features/admin/api/useProfiles.ts
@@ -3,7 +3,6 @@ import useGet2 from "@/composables/useGet2";
 
 export type ActivityState = "green" | "yellow" | "orange" | "red";
 
-
 export interface OrgUserSmall {
   id: number;
   user_id: number;

--- a/src/features/admin/views/AdminOrgUsers.vue
+++ b/src/features/admin/views/AdminOrgUsers.vue
@@ -20,35 +20,35 @@ const activityFilter = ref<FilterOption>("all");
 
 const filterOptions = [
   {
-    label: "Alle",
+    label: "All",
     value: "all" as FilterOption,
     activeClasses: "bg-gray-800 text-white border-gray-800",
     inactiveClasses:
       "bg-white text-gray-700 border-gray-300 hover:border-gray-500",
   },
   {
-    label: "Aktiv (3 Mo.)",
+    label: "Active (3 mo.)",
     value: "green" as FilterOption,
     activeClasses: "bg-green-100 text-green-800 border-green-500",
     inactiveClasses:
       "bg-white text-green-800 border-green-200 hover:border-green-400",
   },
   {
-    label: "Aktiv (6 Mo.)",
+    label: "Active (6 mo.)",
     value: "yellow" as FilterOption,
     activeClasses: "bg-yellow-100 text-yellow-800 border-yellow-500",
     inactiveClasses:
       "bg-white text-yellow-800 border-yellow-200 hover:border-yellow-400",
   },
   {
-    label: "Eingeloggt (6 Mo.)",
+    label: "Logged in (6 mo.)",
     value: "orange" as FilterOption,
     activeClasses: "bg-orange-100 text-orange-800 border-orange-500",
     inactiveClasses:
       "bg-white text-orange-800 border-orange-200 hover:border-orange-400",
   },
   {
-    label: "Inaktiv (12+ Mo.)",
+    label: "Inactive (12+ mo.)",
     value: "red" as FilterOption,
     activeClasses: "bg-red-100 text-red-800 border-red-500",
     inactiveClasses:
@@ -106,7 +106,7 @@ function getSortValue(
           id="activity-filter-label"
           class="text-sm font-medium text-gray-700"
         >
-          Aktivität:
+          Activity:
         </span>
         <div class="flex flex-wrap gap-1">
           <button
@@ -128,6 +128,7 @@ function getSortValue(
       </div>
 
       <TableSortable
+        v-if="filteredProfiles?.length !== 0"
         sort-key="activity_state"
         sort-order="ASC"
         :get-value-func="getSortValue"
@@ -137,7 +138,7 @@ function getSortValue(
           { name: 'Phone', key: 'phone_number' },
           { name: 'Groups', key: 'group_names' },
           { name: 'Last Login', key: 'last_login_month', sortable: true },
-          { name: 'Aktivität', key: 'activity_state', sortable: true },
+          { name: 'Activity', key: 'activity_state', sortable: true },
           { name: '', key: 'action' },
         ]"
         :data="filteredProfiles"
@@ -198,6 +199,9 @@ function getSortValue(
           />
         </template>
       </TableSortable>
+      <div v-else class="py-10 text-sm text-center text-gray-500">
+        No users match the selected activity filter.
+      </div>
     </div>
   </BoxLoader>
 </template>

--- a/src/features/admin/views/AdminOrgUsers.vue
+++ b/src/features/admin/views/AdminOrgUsers.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
+import { computed, ref } from "vue";
 import BoxLoader from "@/components/BoxLoader.vue";
-import { TableGenerator } from "lorga-ui";
+import ActivityBadge from "@/components/ActivityBadge.vue";
+import { TableSortable } from "lorga-ui";
 import BreadcrumbsBar from "@/components/BreadcrumbsBar.vue";
 import { CogIcon } from "@heroicons/vue/24/outline";
 import ButtonLink from "@/components/ButtonLink.vue";
@@ -8,9 +10,80 @@ import UsersDeleteUser from "@/features/admin/actions/DeleteUser.vue";
 import UsersActivateDeactivateUser from "@/features/admin/actions/ActivateDeactivateUser.vue";
 import UsersAcceptUser from "@/features/admin/actions/AcceptOrgUser.vue";
 import UsersUnlockUser from "@/features/admin/actions/UnlockUser.vue";
-import { useProfiles } from "../api/useProfiles";
+import { useProfiles, type ActivityState } from "../api/useProfiles";
 
 const { profiles, query } = useProfiles();
+
+type FilterOption = ActivityState | "all";
+
+const activityFilter = ref<FilterOption>("all");
+
+const filterOptions = [
+  {
+    label: "Alle",
+    value: "all" as FilterOption,
+    activeClasses: "bg-gray-800 text-white border-gray-800",
+    inactiveClasses:
+      "bg-white text-gray-700 border-gray-300 hover:border-gray-500",
+  },
+  {
+    label: "Aktiv (3 Mo.)",
+    value: "green" as FilterOption,
+    activeClasses: "bg-green-100 text-green-800 border-green-500",
+    inactiveClasses:
+      "bg-white text-green-800 border-green-200 hover:border-green-400",
+  },
+  {
+    label: "Aktiv (6 Mo.)",
+    value: "yellow" as FilterOption,
+    activeClasses: "bg-yellow-100 text-yellow-800 border-yellow-500",
+    inactiveClasses:
+      "bg-white text-yellow-800 border-yellow-200 hover:border-yellow-400",
+  },
+  {
+    label: "Eingeloggt (6 Mo.)",
+    value: "orange" as FilterOption,
+    activeClasses: "bg-orange-100 text-orange-800 border-orange-500",
+    inactiveClasses:
+      "bg-white text-orange-800 border-orange-200 hover:border-orange-400",
+  },
+  {
+    label: "Inaktiv (12+ Mo.)",
+    value: "red" as FilterOption,
+    activeClasses: "bg-red-100 text-red-800 border-red-500",
+    inactiveClasses:
+      "bg-white text-red-800 border-red-200 hover:border-red-400",
+  },
+];
+
+function toggleFilter(value: FilterOption) {
+  activityFilter.value = activityFilter.value === value ? "all" : value;
+}
+
+const filteredProfiles = computed(() => {
+  if (!profiles.value) return null;
+  if (activityFilter.value === "all") return profiles.value;
+  return profiles.value.filter(
+    (profile) => profile.activity_state === activityFilter.value,
+  );
+});
+
+const activityOrder: Record<ActivityState, number> = {
+  green: 1,
+  yellow: 2,
+  orange: 3,
+  red: 4,
+};
+
+function getSortValue(
+  item: Record<string, unknown>,
+  key: string,
+): string | number {
+  if (key === "activity_state")
+    return activityOrder[item.activity_state as ActivityState] ?? 0;
+  const value = item[key];
+  return typeof value === "string" || typeof value === "number" ? value : "";
+}
 </script>
 
 <template>
@@ -23,64 +96,108 @@ const { profiles, query } = useProfiles();
       >
         <CogIcon class="w-6 h-6" />
       </BreadcrumbsBar>
-      <TableGenerator
+
+      <div
+        class="flex items-center gap-2"
+        role="group"
+        aria-labelledby="activity-filter-label"
+      >
+        <span
+          id="activity-filter-label"
+          class="text-sm font-medium text-gray-700"
+        >
+          Aktivität:
+        </span>
+        <div class="flex flex-wrap gap-1">
+          <button
+            v-for="option in filterOptions"
+            :key="option.value"
+            type="button"
+            :aria-pressed="activityFilter === option.value"
+            :class="[
+              'px-3 py-1 text-sm rounded-full border transition-colors',
+              activityFilter === option.value
+                ? option.activeClasses
+                : option.inactiveClasses,
+            ]"
+            @click="toggleFilter(option.value)"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+      </div>
+
+      <TableSortable
+        sort-key="activity_state"
+        sort-order="ASC"
+        :get-value-func="getSortValue"
         :head="[
-          { name: 'Name', key: 'name' },
+          { name: 'Name', key: 'name', sortable: true },
           { name: 'E-Mail', key: 'email' },
           { name: 'Phone', key: 'phone_number' },
-          { name: 'Groups', fn: (i) => i.group_names.join(', ') },
-          { name: 'Last Login', key: 'last_login_month' },
+          { name: 'Groups', key: 'group_names' },
+          { name: 'Last Login', key: 'last_login_month', sortable: true },
+          { name: 'Aktivität', key: 'activity_state', sortable: true },
           { name: '', key: 'action' },
         ]"
-        :data="profiles"
+        :data="filteredProfiles"
       >
-        <template #name="{ i }">
+        <template #group_names="{ item }">
+          {{ item.group_names.join(", ") }}
+        </template>
+        <template #name="{ item }">
           <div class="flex items-center space-x-1">
             <ButtonLink
               :to="{
                 name: 'admin-profile',
-                params: { id: i.id },
+                params: { id: item.id },
               }"
             >
               <span class="whitespace-nowrap">
-                {{ i.name }}
+                {{ item.name }}
               </span>
             </ButtonLink>
-            <template v-for="q in i.qualifications" :key="q">
+            <template
+              v-for="qualification in item.qualifications"
+              :key="qualification"
+            >
               <span
                 class="inline-flex items-center px-2 py-1 text-xs font-medium text-green-800 bg-green-100 rounded-full"
               >
-                {{ q }}
+                {{ qualification }}
               </span>
             </template>
           </div>
         </template>
-        <template #action="slotProps">
+        <template #activity_state="{ item }">
+          <ActivityBadge :state="item.activity_state" />
+        </template>
+        <template #action="{ item }">
           <UsersAcceptUser
             :query="query"
-            :user-name="slotProps.name"
-            :user-id="slotProps.id"
-            :user-accepted="slotProps.accepted"
+            :user-name="item.name"
+            :user-id="item.id"
+            :user-accepted="item.accepted"
           />
           <UsersUnlockUser
             :query="query"
-            :user-name="slotProps.name"
-            :user-id="slotProps.id"
-            :user-locked="slotProps.locked"
+            :user-name="item.name"
+            :user-id="item.id"
+            :user-locked="item.locked"
           />
           <UsersActivateDeactivateUser
             :query="query"
-            :user-name="slotProps.name"
-            :user-id="slotProps.id"
-            :user-active="slotProps.is_active"
+            :user-name="item.name"
+            :user-id="item.id"
+            :user-active="item.is_active"
           />
           <UsersDeleteUser
             :query="query"
-            :user-name="slotProps.name"
-            :user-id="slotProps.id"
+            :user-name="item.name"
+            :user-id="item.id"
           />
         </template>
-      </TableGenerator>
+      </TableSortable>
     </div>
   </BoxLoader>
 </template>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR shows if users have recently been active in the admin profiles view.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add a new column to the Admin Profiles with the new field created in [this PR](https://github.com/lawandorga/lawandorga-backend-service/pull/614)
- Enable sorting in the Profiles view
- Add a filter at the top of the Profiles view to only show profiles whose last activity was in a certain time frame

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I wonder if we really need to have filtering and sorting in the view, but I guess we can put it in for now, and if we need the space, we can always remove the filtering very easily.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Run the app against [backend branch](https://github.com/lawandorga/lawandorga-backend-service/pull/614) and then open the http://localhost:4204/admin/profiles/

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: https://github.com/lawandorga/lawandorga-backend-service/pull/614

