### PR TITLE
627: Change textarea to WYSIWYG field for task description

### DIFF
--- a/src/features/dashboard/actions/CreateTask.vue
+++ b/src/features/dashboard/actions/CreateTask.vue
@@ -1,26 +1,8 @@
-<template>
-  <ButtonNormal kind="secondary" @click="commandModalOpen = true">
-    Create Task
-    <ModalCreate
-      v-model="commandModalOpen"
-      title="Create Task"
-      :fields="taskFields"
-      submit="Create"
-      :request="commandRequest"
-      :data="{
-        action: 'tasks/create_task',
-        page_url: route.fullPath,
-        priority: 'medium',
-        progress: 0,
-      }"
-    />
-  </ButtonNormal>
-</template>
-
 <script setup lang="ts">
 import { ButtonNormal, ModalCreate, types } from "lorga-ui";
 import { computed } from "vue";
 import { useRoute } from "vue-router";
+import FormWysiwyg from "@/components/FormWysiwyg.vue";
 
 import useCmd from "@/composables/useCmd";
 import { useProfiles } from "@/features/admin/api/useProfiles";
@@ -34,10 +16,8 @@ const taskFields = computed<types.FormField[]>(() => [
   { label: "Location", name: "page_url", type: "text" },
   { label: "Title", name: "title", required: true, type: "text" },
   {
-    label: "Description",
     name: "description",
-    required: false,
-    type: "textarea",
+    type: "slot",
   },
   {
     label: "Deadline",
@@ -84,3 +64,27 @@ const taskFields = computed<types.FormField[]>(() => [
 
 const { commandModalOpen, commandRequest } = useCmd(notifyTasksChanged);
 </script>
+
+<template>
+  <ButtonNormal kind="secondary" @click="commandModalOpen = true">
+    Create Task
+    <ModalCreate
+      v-model="commandModalOpen"
+      title="Create Task"
+      :fields="taskFields"
+      submit="Create"
+      :request="commandRequest"
+      :data="{
+        action: 'tasks/create_task',
+        page_url: route.fullPath,
+        priority: 'medium',
+        progress: 0,
+      }"
+    >
+      <template #description="{ data }">
+        <FormWysiwyg v-model="data.description" label="Description" />
+      </template>
+    </ModalCreate>
+  </ButtonNormal>
+</template>
+

--- a/src/features/dashboard/actions/EditTask.vue
+++ b/src/features/dashboard/actions/EditTask.vue
@@ -2,6 +2,7 @@
 import { ButtonNormal, types, ModalFree, FormGenerator } from "lorga-ui";
 import { computed, toRefs } from "vue";
 
+import FormWysiwyg from "@/components/FormWysiwyg.vue";
 import useCmd from "@/composables/useCmd";
 import { useProfiles } from "@/features/admin/api/useProfiles";
 import { Task } from "@/features/dashboard/api/useTasks";
@@ -23,10 +24,8 @@ const taskFields = computed<types.FormField[]>(() => [
   },
   { label: "Title", name: "title", required: true, type: "text" },
   {
-    label: "Description",
     name: "description",
-    required: false,
-    type: "textarea",
+    type: "slot",
   },
   {
     label: "Deadline",
@@ -97,6 +96,9 @@ const { commandRequest: commandRequestThatDoesNotCloseModal } = useCmd(
         }"
       >
         <template #custom>Created by: {{ task.creator_name }}</template>
+        <template #description="{ data }">
+          <FormWysiwyg v-model="data.description" label="Description" />
+        </template>
       </FormGenerator>
       <FormGenerator
         :request="commandRequestThatDoesNotCloseModal"
@@ -126,7 +128,7 @@ const { commandRequest: commandRequestThatDoesNotCloseModal } = useCmd(
               <div
                 v-for="(c, index) in task.comments"
                 :key="index"
-                class="border-l-2 border-gray-300 py-1 pl-3 text-sm"
+                class="py-1 pl-3 text-sm border-l-2 border-gray-300"
               >
                 <div class="flex items-baseline justify-between gap-3">
                   <span class="font-semibold text-gray-600">{{


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
This PR changes the description field for tasks to a WYSIWYG field

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Change textarea to WYSIWYG field

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None are intended

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
- Please test if the description of tasks is editable for create new tasks and update tasks

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #627
