### PR TITLE
Add precommit jobs to the pipeline checks

### DIFF
--- a/.github/workflows/commit-stage--verify-code.yml
+++ b/.github/workflows/commit-stage--verify-code.yml
@@ -1,10 +1,10 @@
-name: Commit Stage - Check Code With ESLint
+name: Commit Stage - Verify Code
 
 on: workflow_call
 
 jobs:
-  lint:
-    name: Lint
+  verify:
+    name: Verify
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -19,5 +19,14 @@ jobs:
       - name: Install Packages
         run: npm ci --force
 
+      - name: Run Format Check
+        run: npm run format:check
+
       - name: Run Lint
         run: npm run lint
+
+      - name: Run TS Check
+        run: npm run tscheck
+
+      - name: Run Tests
+        run: npm run test

--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -18,9 +18,9 @@ jobs:
       artifact: ${{ github.event.repository.name }}
       version: ${{ github.sha }}
 
-  eslint:
-    name: ESLint
-    uses: ./.github/workflows/commit-stage--run-eslint-on-code.yml
+  verify:
+    name: Verify
+    uses: ./.github/workflows/commit-stage--verify-code.yml
 
   analyze:
     name: Analyze


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
I keep having formatting changes unrelated to my changes when I run the precommit locally, and I realised that it's because the formatting doesn't run on the pipeline. This fixes that.

I tested it locally using [act](https://github.com/nektos/act), which should be fine here.