### PR TITLE
638: Add new badge for notes

### DIFF
--- a/src/features/dashboard/api/useNotes.ts
+++ b/src/features/dashboard/api/useNotes.ts
@@ -8,6 +8,7 @@ export interface DashboardNote {
   note: string;
   order: number;
   is_wide: boolean;
+  is_new: boolean;
 }
 
 export function useNotes() {

--- a/src/features/dashboard/api/useTasks.ts
+++ b/src/features/dashboard/api/useTasks.ts
@@ -27,6 +27,7 @@ export interface Task {
   created_at: string;
   updated_at: string;
   page_url: string;
+  is_new: boolean;
 }
 
 export function useTasks() {

--- a/src/features/dashboard/components/OrgNotes.vue
+++ b/src/features/dashboard/components/OrgNotes.vue
@@ -19,10 +19,15 @@ const { notes, notesQuery } = useNotes();
       <article
         v-for="note in notes"
         :key="note.id"
-        class="rounded bg-white px-6 pt-4 pb-4 shadow"
+        class="relative rounded bg-white px-6 pt-4 pb-4 shadow"
         :class="{ 'lg:col-span-2': note.is_wide }"
       >
-        <h3 class="mb-2 font-medium text-gray-700">
+        <span
+          v-if="note.is_new"
+          class="bg-formcolor absolute top-0 right-3 px-2 py-1 text-sm font-bold text-white"
+          >New</span
+        >
+        <h3 class="my-2 font-medium text-gray-700 [.bg-formcolor+&]:pe-12">
           {{ note.title }}
         </h3>
         <!-- eslint-disable vue/no-v-html -->

--- a/src/features/dashboard/components/SingleTask.vue
+++ b/src/features/dashboard/components/SingleTask.vue
@@ -63,15 +63,20 @@ const priorityColor: Record<string, string> = {
 
 <template>
   <article
-    class="flex flex-col justify-between rounded bg-white px-6 pt-4 pb-4 shadow"
+    class="relative flex flex-col justify-between rounded bg-white px-6 pt-4 pb-4 shadow"
   >
+    <span
+      v-if="task.is_new"
+      class="bg-formcolor absolute top-0 right-3 px-2 py-1 text-sm font-bold text-white"
+      >New</span
+    >
     <div>
       <div class="flex items-start justify-between gap-3">
         <h3 class="text-formcolor mb-2 text-left font-semibold">
           {{ task.title }}
         </h3>
-        <EditTask v-if="!task.is_done" :task="task" :query="query" />
-        <DeleteTask v-if="task.is_done" :task="task" :query="query" />
+        <EditTask class="relative top-5" v-if="!task.is_done" :task="task" :query="query" />
+        <DeleteTask class="relative top-5" v-if="task.is_done" :task="task" :query="query" />
       </div>
       <p
         v-if="task.page_url"


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
This PR adds a new badge for notes and tasks. The badge appears when a note or task has been created since the last login of our user. 

### Proposed Changes
<!-- Describe this PR in more detail. -->

- Add badge to tasks and notes

### Side Effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing
<!-- List all things that should be tested while reviewing this PR. -->

- Run this PR against the according PR [in the backend](https://github.com/lawandorga/lawandorga-backend-service/pull/643).
- Check if the badge appears for new tasks and notes
- Check that the badge looks good, even if there is a long title
 
### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #638
