### PR TITLE
Calendar beautification

### DIFF
--- a/src/features/calendar/actions/CreateEvent.vue
+++ b/src/features/calendar/actions/CreateEvent.vue
@@ -73,8 +73,8 @@ const request = (data: Record<string, unknown>) => {
   return commandRequest(normalized);
 };
 
-// lorga-ui re-clones :data into the form only when the object reference
-// changes, so open() assigns a fresh object here instead of mutating it
+// lorga-ui re-clones :data into the form only when the object reference changes,
+// so open() assigns a fresh object here to reset the form on each opening
 const initialData = ref<Record<string, unknown>>(buildInitialData());
 
 defineExpose({

--- a/src/features/calendar/actions/CreateEvent.vue
+++ b/src/features/calendar/actions/CreateEvent.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ModalCreate, types } from "lorga-ui";
-import { toRefs } from "vue";
+import { ref, toRefs } from "vue";
 
 import useCmd from "@/composables/useCmd";
+import { toLocalDateTimeInput } from "@/utils/date";
 
 import CalendarTypePicker from "../components/CalendarTypePicker.vue";
 import CalendarWhenFields from "../components/CalendarWhenFields.vue";
@@ -11,6 +12,30 @@ const props = defineProps<{ query: () => void }>();
 const { query } = toRefs(props);
 
 const { commandRequest, commandModalOpen } = useCmd(query);
+
+const DEFAULT_DURATION_MS = 30 * 60 * 1000;
+
+interface EventTimePrefill {
+  start: Date;
+  end?: Date;
+  allDay?: boolean;
+}
+
+const buildInitialData = (prefill?: EventTimePrefill) => {
+  const start = prefill?.start ?? new Date();
+  const defaultEnd = new Date(start.getTime() + DEFAULT_DURATION_MS);
+  const end = prefill?.end ?? (prefill?.allDay ? null : defaultEnd);
+
+  return {
+    action: "calendar/create_event",
+    event_type: "APPOINTMENT",
+    is_all_day: prefill?.allDay ?? false,
+    start_time: toLocalDateTimeInput(start.toISOString()),
+    end_time: end ? toLocalDateTimeInput(end.toISOString()) : "",
+    recurrence_rule: "",
+    recurrence_until: "",
+  };
+};
 
 const fields: types.FormField[] = [
   {
@@ -48,8 +73,13 @@ const request = (data: Record<string, unknown>) => {
   return commandRequest(normalized);
 };
 
+// lorga-ui re-clones :data into the form only when the object reference
+// changes, so open() assigns a fresh object here instead of mutating it
+const initialData = ref<Record<string, unknown>>(buildInitialData());
+
 defineExpose({
-  open: () => {
+  open: (prefill?: EventTimePrefill) => {
+    initialData.value = buildInitialData(prefill);
     commandModalOpen.value = true;
   },
 });
@@ -61,16 +91,7 @@ defineExpose({
     title="Create Event"
     :fields="fields"
     :request="request"
-    :data="{
-      action: 'calendar/create_event',
-      event_type: 'APPOINTMENT',
-      is_all_day: false,
-      start_time: new Date().toISOString().slice(0, 14) + '00',
-      end_time:
-        new Date(Date.now() + 3600000).toISOString().slice(0, 14) + '00',
-      recurrence_rule: '',
-      recurrence_until: '',
-    }"
+    :data="initialData"
     submit="Create"
   >
     <template #event_type="{ data }">

--- a/src/features/calendar/actions/CreateEvent.vue
+++ b/src/features/calendar/actions/CreateEvent.vue
@@ -83,6 +83,7 @@ defineExpose({
         v-model:end="data.end_time"
         v-model:recurrence-rule="data.recurrence_rule"
         v-model:recurrence-until="data.recurrence_until"
+        :event-type="data.event_type"
       />
     </template>
   </ModalCreate>

--- a/src/features/calendar/actions/UpdateEvent.vue
+++ b/src/features/calendar/actions/UpdateEvent.vue
@@ -8,12 +8,13 @@ import { toLocalDateTimeInput } from "@/utils/date";
 
 import CalendarTypePicker from "../components/CalendarTypePicker.vue";
 import CalendarWhenFields from "../components/CalendarWhenFields.vue";
+import type { EventType } from "../constants";
 
 const props = defineProps<{
   query: () => void;
   eventUuid: string;
   eventTitle: string;
-  eventType: "APPOINTMENT" | "TASK" | "MEETING" | "DEADLINE" | "EXTERNAL";
+  eventType: EventType;
   startTime: string;
   endTime: string | null;
   isAllDay: boolean;
@@ -117,6 +118,7 @@ watch(openSignal, (next, prev) => {
         v-model:end="data.end_time"
         v-model:recurrence-rule="data.recurrence_rule"
         v-model:recurrence-until="data.recurrence_until"
+        :event-type="data.event_type"
       />
     </template>
   </ModalUpdate>

--- a/src/features/calendar/api/toFullCalendarEvent.ts
+++ b/src/features/calendar/api/toFullCalendarEvent.ts
@@ -1,5 +1,7 @@
 import type { EventInput } from "@fullcalendar/core";
 
+import { addDays, dateWithTimeOf } from "@/utils/date";
+
 import {
   EVENT_TYPE_META,
   RECURRENCE_FREQUENCIES,
@@ -8,6 +10,7 @@ import {
 import type { CalendarEvent } from "./useCalendarEvents";
 
 const MILLISECONDS_PER_MINUTE = 60000;
+const MILLISECONDS_PER_DAY = 86400000;
 
 const getEventTypeColor = (eventType: CalendarEvent["event_type"]): string =>
   EVENT_TYPE_META[eventType].color;
@@ -16,29 +19,42 @@ const getFullCalendarFrequency = (rule: string): string | undefined =>
   RECURRENCE_FREQUENCIES.find((frequency) => frequency.rule === rule)
     ?.fullCalendarFreq;
 
-const getEventDuration = (event: CalendarEvent): { minutes: number } | null => {
-  if (event.is_all_day || !event.end_time) return null;
-  const durationMs =
-    new Date(event.end_time).getTime() - new Date(event.start_time).getTime();
-  if (durationMs <= 0) return null;
-  return { minutes: Math.round(durationMs / MILLISECONDS_PER_MINUTE) };
+// FullCalendar's all-day end is exclusive, we want to store (and show) the last day included
+const toExclusiveAllDayEnd = (endTime: string): string =>
+  addDays(new Date(endTime), 1).toISOString();
+
+const millisecondsBetween = (start: string, end: string): number =>
+  new Date(end).getTime() - new Date(start).getTime();
+
+const getAllDayDuration = (event: CalendarEvent): { days: number } | null => {
+  if (!event.end_time) return null;
+  const elapsedMilliseconds = millisecondsBetween(
+    event.start_time,
+    event.end_time,
+  );
+  // Rounding because of daylight savings time; +1 to include the last day
+  const days = Math.round(elapsedMilliseconds / MILLISECONDS_PER_DAY) + 1;
+  return days > 1 ? { days } : null;
 };
 
-export const toFullCalendarEvent = (event: CalendarEvent): EventInput => {
-  const color = getEventTypeColor(event.event_type);
-  const baseEvent = {
-    id: event.uuid,
-    title: event.title,
-    allDay: event.is_all_day,
-    backgroundColor: `${color}${TYPE_TINT_ALPHA}`,
-    borderColor: color, // TODO: calendar source color in the future
-    textColor: color,
-    extendedProps: { calendarEvent: event },
-  };
+const getTimedDuration = (event: CalendarEvent): { minutes: number } | null => {
+  if (!event.end_time) return null;
+  const elapsedMilliseconds = millisecondsBetween(
+    event.start_time,
+    event.end_time,
+  );
+  if (elapsedMilliseconds <= 0) return null;
+  return { minutes: elapsedMilliseconds / MILLISECONDS_PER_MINUTE };
+};
 
+const buildAllDayEvent = (
+  event: CalendarEvent,
+  baseEvent: EventInput,
+): EventInput => {
   const frequency = getFullCalendarFrequency(event.recurrence_rule);
+
   if (frequency) {
-    const duration = getEventDuration(event);
+    const duration = getAllDayDuration(event);
     return {
       ...baseEvent,
       rrule: {
@@ -53,6 +69,51 @@ export const toFullCalendarEvent = (event: CalendarEvent): EventInput => {
   return {
     ...baseEvent,
     start: event.start_time,
+    end: event.end_time ? toExclusiveAllDayEnd(event.end_time) : undefined,
+  };
+};
+
+const buildTimedEvent = (
+  event: CalendarEvent,
+  baseEvent: EventInput,
+): EventInput => {
+  const frequency = getFullCalendarFrequency(event.recurrence_rule);
+
+  if (frequency) {
+    const duration = getTimedDuration(event);
+    return {
+      ...baseEvent,
+      rrule: {
+        freq: frequency,
+        dtstart: event.start_time,
+        ...(event.recurrence_until
+          ? { until: dateWithTimeOf(event.recurrence_until, event.start_time) }
+          : {}),
+      },
+      ...(duration ? { duration } : {}),
+    };
+  }
+
+  return {
+    ...baseEvent,
+    start: event.start_time,
     end: event.end_time ?? undefined,
   };
+};
+
+export const toFullCalendarEvent = (event: CalendarEvent): EventInput => {
+  const color = getEventTypeColor(event.event_type);
+  const baseEvent: EventInput = {
+    id: event.uuid,
+    title: event.title,
+    allDay: event.is_all_day,
+    backgroundColor: `${color}${TYPE_TINT_ALPHA}`,
+    borderColor: color, // TODO: calendar source color in the future
+    textColor: color,
+    extendedProps: { calendarEvent: event },
+  };
+
+  return event.is_all_day
+    ? buildAllDayEvent(event, baseEvent)
+    : buildTimedEvent(event, baseEvent);
 };

--- a/src/features/calendar/api/toFullCalendarEvent.ts
+++ b/src/features/calendar/api/toFullCalendarEvent.ts
@@ -101,12 +101,18 @@ const buildTimedEvent = (
   };
 };
 
-export const toFullCalendarEvent = (event: CalendarEvent): EventInput => {
+export const toFullCalendarEvent = (
+  event: CalendarEvent,
+  currentUserId?: number,
+): EventInput => {
   const color = getEventTypeColor(event.event_type);
+  const isEditable =
+    event.creator_id === currentUserId && event.recurrence_rule === "";
   const baseEvent: EventInput = {
     id: event.uuid,
     title: event.title,
     allDay: event.is_all_day,
+    editable: isEditable,
     backgroundColor: `${color}${TYPE_TINT_ALPHA}`,
     borderColor: color, // TODO: calendar source color in the future
     textColor: color,

--- a/src/features/calendar/api/useCalendarEvents.ts
+++ b/src/features/calendar/api/useCalendarEvents.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from "vue";
 
 import useGet2 from "@/composables/useGet2";
+import { useUserStore } from "@/store/user";
 
 import type { EventType } from "../constants";
 import { toFullCalendarEvent } from "./toFullCalendarEvent";
@@ -25,11 +26,14 @@ export interface CalendarEvent {
 }
 
 export function useCalendarEvents() {
+  const userStore = useUserStore();
   const calendarEvents = ref<CalendarEvent[] | undefined>(undefined);
   const query = useGet2("api/calendar/query/events/", calendarEvents);
 
   const fullCalendarEvents = computed(() =>
-    (calendarEvents.value ?? []).map(toFullCalendarEvent),
+    (calendarEvents.value ?? []).map((event) =>
+      toFullCalendarEvent(event, userStore.user?.id),
+    ),
   );
 
   const isLoading = computed(() => calendarEvents.value === undefined);

--- a/src/features/calendar/components/CalendarEventDetail.vue
+++ b/src/features/calendar/components/CalendarEventDetail.vue
@@ -63,12 +63,25 @@ const sourceMeta = computed(() => {
   };
 });
 
-const formattedDate = computed(() => {
-  if (!props.event) return "";
-  const weekday = new Date(props.event.start_time).toLocaleDateString("en-GB", {
+const toWeekdayDate = (value: string): string => {
+  const weekday = new Date(value).toLocaleDateString("en-GB", {
     weekday: "long",
   });
-  return `${weekday}, ${formatDate(props.event.start_time, true)}`;
+  return `${weekday}, ${formatDate(value, true)}`;
+};
+
+const formattedDate = computed(() => {
+  if (!props.event) return "";
+  const { start_time, end_time, is_all_day } = props.event;
+  const startLabel = toWeekdayDate(start_time);
+  if (
+    is_all_day &&
+    end_time &&
+    formatDate(start_time, true) !== formatDate(end_time, true)
+  ) {
+    return `${startLabel} - ${toWeekdayDate(end_time)}`;
+  }
+  return startLabel;
 });
 
 const recurrenceLabel = computed(() => {

--- a/src/features/calendar/components/CalendarEventDetail.vue
+++ b/src/features/calendar/components/CalendarEventDetail.vue
@@ -170,9 +170,7 @@ const openDeleteModal = () => {
         </CalendarDetailRow>
       </dl>
 
-      <div
-        class="mt-5 flex justify-between gap-3 rounded-sm bg-gray-100 px-5 py-2"
-      >
+      <div class="mt-5 flex items-center justify-between gap-3">
         <ButtonNormal
           v-if="canDelete"
           kind="delete"

--- a/src/features/calendar/components/CalendarWhenFields.vue
+++ b/src/features/calendar/components/CalendarWhenFields.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { FormInput } from "lorga-ui";
-import { computed } from "vue";
+import { computed, watch } from "vue";
 
-import { RECURRENCE_FREQUENCIES } from "../constants";
+import { type EventType, RECURRENCE_FREQUENCIES } from "../constants";
 
 const props = defineProps<{
   isAllDay: boolean;
@@ -10,6 +10,7 @@ const props = defineProps<{
   end: string;
   recurrenceRule: string;
   recurrenceUntil: string;
+  eventType: EventType;
 }>();
 
 const emit = defineEmits<{
@@ -87,6 +88,18 @@ const recurrenceUntil = computed<string>({
 });
 
 const isRecurring = computed(() => !!props.recurrenceRule);
+
+const isDeadline = computed<boolean>(() => props.eventType === "DEADLINE");
+
+watch(
+  isDeadline,
+  (deadline) => {
+    if (!deadline) return;
+    if (!props.isAllDay) allDay.value = true;
+    if (props.end) emit("update:end", "");
+  },
+  { immediate: true },
+);
 </script>
 
 <template>
@@ -96,10 +109,11 @@ const isRecurring = computed(() => !!props.recurrenceRule);
         v-model="startDate"
         name="start_time"
         type="date"
-        label="Start date"
+        :label="isDeadline ? 'Date' : 'Start date'"
         required
       />
       <FormInput
+        v-if="!isDeadline"
         v-model="endDate"
         name="end_time"
         type="date"
@@ -124,12 +138,15 @@ const isRecurring = computed(() => !!props.recurrenceRule);
 
     <div class="flex items-center justify-between gap-3">
       <label
-        class="flex cursor-pointer items-center gap-2 text-sm font-medium text-gray-700 select-none"
+        class="flex items-center gap-2 text-sm font-medium text-gray-700 select-none"
+        :class="isDeadline ? 'cursor-not-allowed' : 'cursor-pointer'"
+        :title="isDeadline ? 'Deadlines are always all-day events.' : undefined"
       >
         <input
           v-model="allDay"
           type="checkbox"
-          class="size-4"
+          class="size-4 disabled:opacity-60"
+          :disabled="isDeadline"
           style="accent-color: var(--color-formcolor)"
         />
         All day

--- a/src/features/calendar/tests/toFullCalendarEvent.test.ts
+++ b/src/features/calendar/tests/toFullCalendarEvent.test.ts
@@ -34,7 +34,7 @@ describe("toFullCalendarEvent", () => {
     expect(result.editable).toBe(false);
   });
 
-  it("keeps recurring events non-editable even for the creator", () => {
+  it("keeps recurring events non-editable by drag-and-drop even for the creator", () => {
     const result = toFullCalendarEvent(
       makeEvent({ creator_id: 7, recurrence_rule: "FREQ=WEEKLY" }),
       7,

--- a/src/features/calendar/tests/toFullCalendarEvent.test.ts
+++ b/src/features/calendar/tests/toFullCalendarEvent.test.ts
@@ -56,7 +56,10 @@ describe("toFullCalendarEvent", () => {
       makeEvent({ recurrence_rule: "FREQ=DAILY", recurrence_until: null }),
     );
 
-    expect(withUntil).toHaveProperty("rrule.until", "2026-06-01");
+    expect(withUntil).toHaveProperty(
+      "rrule.until",
+      "2026-06-01T10:00:00+01:00",
+    );
     expect(withoutUntil).not.toHaveProperty("rrule.until");
   });
 
@@ -68,13 +71,49 @@ describe("toFullCalendarEvent", () => {
     expect(result).toHaveProperty("duration", { minutes: 90 });
   });
 
-  it("omits duration for all-day recurring events", () => {
+  it("omits duration for single-day all-day recurring events", () => {
     const result = toFullCalendarEvent(
       makeEvent({ recurrence_rule: "FREQ=WEEKLY", is_all_day: true }),
     );
 
     expect(result).toHaveProperty("rrule.freq", "weekly");
     expect(result).not.toHaveProperty("duration");
+  });
+
+  it("spans the inclusive day count for multi-day all-day recurring events", () => {
+    const result = toFullCalendarEvent(
+      makeEvent({
+        recurrence_rule: "FREQ=WEEKLY",
+        is_all_day: true,
+        start_time: "2026-03-16T00:00:00",
+        end_time: "2026-03-18T00:00:00", // inclusive 16th–18th = 3 days
+      }),
+    );
+
+    expect(result).toHaveProperty("duration", { days: 3 });
+  });
+
+  it("extends an all-day event's end to the exclusive next day", () => {
+    const result = toFullCalendarEvent(
+      makeEvent({
+        is_all_day: true,
+        start_time: "2026-03-16T00:00:00",
+        end_time: "2026-03-18T00:00:00",
+      }),
+    );
+
+    expect(result.start).toBe("2026-03-16T00:00:00");
+    // inclusive 18th → exclusive 19th (one calendar day later)
+    expect(result.end).toBe(new Date("2026-03-19T00:00:00").toISOString());
+  });
+
+  it("leaves an all-day event without an end as a single day", () => {
+    const result = toFullCalendarEvent(
+      makeEvent({ is_all_day: true, end_time: null }),
+    );
+
+    expect(result.end).toBeUndefined();
+    expect(result.allDay).toBe(true);
   });
 
   it("treats an unknown recurrence rule as a one-off event", () => {

--- a/src/features/calendar/tests/toFullCalendarEvent.test.ts
+++ b/src/features/calendar/tests/toFullCalendarEvent.test.ts
@@ -24,6 +24,24 @@ const makeEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
 });
 
 describe("toFullCalendarEvent", () => {
+  it("makes the creator's own non-recurring events editable", () => {
+    const result = toFullCalendarEvent(makeEvent({ creator_id: 7 }), 7);
+    expect(result.editable).toBe(true);
+  });
+
+  it("keeps other users' events non-editable", () => {
+    const result = toFullCalendarEvent(makeEvent({ creator_id: 7 }), 99);
+    expect(result.editable).toBe(false);
+  });
+
+  it("keeps recurring events non-editable even for the creator", () => {
+    const result = toFullCalendarEvent(
+      makeEvent({ creator_id: 7, recurrence_rule: "FREQ=WEEKLY" }),
+      7,
+    );
+    expect(result.editable).toBe(false);
+  });
+
   it("maps a one-off event to start/end without an rrule", () => {
     const result = toFullCalendarEvent(makeEvent());
 

--- a/src/features/calendar/views/CalendarDashboard.vue
+++ b/src/features/calendar/views/CalendarDashboard.vue
@@ -3,13 +3,16 @@ import type {
   CalendarOptions,
   DateSelectArg,
   DayHeaderContentArg,
+  EventApi,
   EventClickArg,
   EventContentArg,
+  EventDropArg,
 } from "@fullcalendar/core";
 import enGBLocale from "@fullcalendar/core/locales/en-gb";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin, {
   type DateClickArg,
+  type EventResizeDoneArg,
 } from "@fullcalendar/interaction";
 import listPlugin from "@fullcalendar/list";
 import rrulePlugin from "@fullcalendar/rrule";
@@ -19,7 +22,8 @@ import { CalendarDaysIcon } from "@heroicons/vue/24/outline";
 import { computed, ref } from "vue";
 
 import BreadcrumbsBar from "@/components/BreadcrumbsBar.vue";
-import { addDays } from "@/utils/date";
+import useCmd from "@/composables/useCmd";
+import { addDays, toLocalDateTimeInput } from "@/utils/date";
 
 import CreateEvent from "../actions/CreateEvent.vue";
 import {
@@ -37,6 +41,8 @@ const CALENDAR_PLUGINS = [
 ];
 
 const { isLoading, fullCalendarEvents, query } = useCalendarEvents();
+
+const { commandRequest: updateEventRequest } = useCmd(query);
 
 const createEventModal = ref<InstanceType<typeof CreateEvent> | null>(null);
 
@@ -65,6 +71,25 @@ const onDateSelect = (selection: DateSelectArg) => {
   });
   selection.view.calendar.unselect();
 };
+
+const persistEventTimes = (event: EventApi, revert: () => void) => {
+  if (!event.start) return;
+  // FullCalendar's end date is exclusive, we want inclusive ones
+  const end = event.allDay && event.end ? addDays(event.end, -1) : event.end;
+  updateEventRequest({
+    action: "calendar/update_event",
+    event_uuid: event.id,
+    is_all_day: event.allDay,
+    start_time: toLocalDateTimeInput(event.start.toISOString()),
+    end_time: end ? toLocalDateTimeInput(end.toISOString()) : null,
+  }).catch(revert);
+};
+
+const onEventDrop = (drop: EventDropArg) =>
+  persistEventTimes(drop.event, drop.revert);
+
+const onEventResize = (resize: EventResizeDoneArg) =>
+  persistEventTimes(resize.event, resize.revert);
 
 const isoWeekNumber = (date: Date): number => {
   const millisecondsPerDay = 86400000;
@@ -238,6 +263,8 @@ const calendarBaseOptions: CalendarOptions = {
   eventClick: onEventClick,
   dateClick: onDateClick,
   select: onDateSelect,
+  eventDrop: onEventDrop,
+  eventResize: onEventResize,
 };
 
 const calendarOptions = computed<CalendarOptions>(() => ({

--- a/src/features/calendar/views/CalendarDashboard.vue
+++ b/src/features/calendar/views/CalendarDashboard.vue
@@ -150,6 +150,7 @@ const eventContent = (props: EventContentArg) => {
   if (props.view.type === "dayGridMonth") return { domNodes: [titleElement] };
   if (props.view.type === "listMonth")
     return listViewEventContent(event, titleElement);
+  if (props.event.allDay) return { domNodes: [titleElement] };
   return gridViewEventContent(event, titleElement);
 };
 

--- a/src/features/calendar/views/CalendarDashboard.vue
+++ b/src/features/calendar/views/CalendarDashboard.vue
@@ -23,6 +23,7 @@ import { computed, ref } from "vue";
 
 import BreadcrumbsBar from "@/components/BreadcrumbsBar.vue";
 import useCmd from "@/composables/useCmd";
+import { useAlertStore } from "@/store/alert";
 import { addDays, toLocalDateTimeInput } from "@/utils/date";
 
 import CreateEvent from "../actions/CreateEvent.vue";
@@ -43,6 +44,8 @@ const CALENDAR_PLUGINS = [
 const { isLoading, fullCalendarEvents, query } = useCalendarEvents();
 
 const { commandRequest: updateEventRequest } = useCmd(query);
+
+const alertStore = useAlertStore();
 
 const createEventModal = ref<InstanceType<typeof CreateEvent> | null>(null);
 
@@ -82,7 +85,9 @@ const persistEventTimes = (event: EventApi, revert: () => void) => {
     is_all_day: event.allDay,
     start_time: toLocalDateTimeInput(event.start.toISOString()),
     end_time: end ? toLocalDateTimeInput(end.toISOString()) : null,
-  }).catch(revert);
+  })
+    .then(() => alertStore.showSuccess("Event updated"))
+    .catch(revert);
 };
 
 const onEventDrop = (drop: EventDropArg) =>

--- a/src/features/calendar/views/CalendarDashboard.vue
+++ b/src/features/calendar/views/CalendarDashboard.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import type {
   CalendarOptions,
+  DateSelectArg,
   DayHeaderContentArg,
   EventClickArg,
   EventContentArg,
 } from "@fullcalendar/core";
 import enGBLocale from "@fullcalendar/core/locales/en-gb";
 import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin, {
+  type DateClickArg,
+} from "@fullcalendar/interaction";
 import listPlugin from "@fullcalendar/list";
 import rrulePlugin from "@fullcalendar/rrule";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -15,6 +19,7 @@ import { CalendarDaysIcon } from "@heroicons/vue/24/outline";
 import { computed, ref } from "vue";
 
 import BreadcrumbsBar from "@/components/BreadcrumbsBar.vue";
+import { addDays } from "@/utils/date";
 
 import CreateEvent from "../actions/CreateEvent.vue";
 import {
@@ -28,11 +33,12 @@ const CALENDAR_PLUGINS = [
   timeGridPlugin,
   listPlugin,
   rrulePlugin,
+  interactionPlugin,
 ];
 
 const { isLoading, fullCalendarEvents, query } = useCalendarEvents();
 
-const createEventModal = ref<{ open: () => void } | null>(null);
+const createEventModal = ref<InstanceType<typeof CreateEvent> | null>(null);
 
 const selectedEvent = ref<CalendarEvent | null>(null);
 const detailOpen = ref(false);
@@ -44,6 +50,20 @@ const onEventClick = (props: EventClickArg) => {
   selectedEvent.value = props.event.extendedProps
     .calendarEvent as CalendarEvent;
   detailOpen.value = true;
+};
+
+const onDateClick = (click: DateClickArg) => {
+  createEventModal.value?.open({ start: click.date, allDay: click.allDay });
+};
+
+const onDateSelect = (selection: DateSelectArg) => {
+  createEventModal.value?.open({
+    start: selection.start,
+    // An all-day selection's end is exclusive in FullCalendar, we want to show the last day the user selected
+    end: selection.allDay ? addDays(selection.end, -1) : selection.end,
+    allDay: selection.allDay,
+  });
+  selection.view.calendar.unselect();
 };
 
 const isoWeekNumber = (date: Date): number => {
@@ -141,7 +161,12 @@ const gridViewEventContent = (
 };
 
 const eventContent = (props: EventContentArg) => {
-  const event = props.event.extendedProps.calendarEvent as CalendarEvent;
+  const event = props.event.extendedProps.calendarEvent as
+    | CalendarEvent
+    | undefined;
+
+  // The drag-to-create preview has no event yet, so just show an empty div
+  if (!event) return { domNodes: [] };
 
   const titleElement = document.createElement("div");
   titleElement.className = "calendar-event__title";
@@ -200,6 +225,10 @@ const calendarBaseOptions: CalendarOptions = {
   eventDisplay: "block",
   expandRows: true,
   editable: false,
+  selectable: true,
+  selectMirror: true,
+  // 5px threshold between a click and a drag event
+  selectMinDistance: 5,
   allDaySlot: true,
   allDayText: "All day",
   scrollTime: "07:00:00",
@@ -207,6 +236,8 @@ const calendarBaseOptions: CalendarOptions = {
   dayHeaderContent,
   eventContent,
   eventClick: onEventClick,
+  dateClick: onDateClick,
+  select: onDateSelect,
 };
 
 const calendarOptions = computed<CalendarOptions>(() => ({

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { dateWithTimeOf } from "./date";
+
+describe("dateWithTimeOf", () => {
+  it("combines a date with the time-of-day and zone of a datetime", () => {
+    expect(dateWithTimeOf("2026-06-27", "2026-06-22T06:30:00Z")).toBe(
+      "2026-06-27T06:30:00Z",
+    );
+  });
+
+  it("preserves a numeric timezone offset", () => {
+    expect(dateWithTimeOf("2026-06-27", "2026-06-22T08:30:00+02:00")).toBe(
+      "2026-06-27T08:30:00+02:00",
+    );
+  });
+
+  it("returns the date unchanged when the datetime carries no time", () => {
+    expect(dateWithTimeOf("2026-06-27", "2026-06-22")).toBe("2026-06-27");
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -51,6 +51,17 @@ export const formatDateToObject = (dateString: string): FormattedDate => {
   };
 };
 
+export const addDays = (date: Date, days: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+export const dateWithTimeOf = (date: string, dateTime: string): string => {
+  const timeOfDay = dateTime.split("T")[1]; // e.g. "06:30:00Z", "08:30:00+02:00"
+  return timeOfDay ? `${date}T${timeOfDay}` : date;
+};
+
 export const toLocalDateTimeInput = (value: string): string => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR should finish the first milestone of the calendar.

Note that it's currently against #634 to avoid merge conflicts.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add deadlines as all-day events in the top row with all-day events
- Add possibility to create events by clicking on the calendar or drag-and-drop on the calendar
- Add possibility do edit events by dragging them around

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Recurring events currently can't be edited by drag-and-drop, because we're currently not handling the possible case of a single event deviating from the recurrence, and it seemed too easy to edit an entire series of events by pulling one thing around a bit.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test the calendar, lots!

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Part of milestone 1 of https://github.com/lawandorga/lawandorga-backend-service/issues/578
