### PR TITLE
656: Add created and updated to notes

### DIFF
--- a/src/features/dashboard/api/useNotes.ts
+++ b/src/features/dashboard/api/useNotes.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import useGet2 from "@/composables/useGet2";
 
@@ -9,12 +9,28 @@ export interface DashboardNote {
   order: number;
   is_wide: boolean;
   is_new: boolean;
+  created: string;
+  updated: string | null;
+}
+
+const UPDATED_BUFFER_MS = 2000;
+
+function resetUpdatedDate(note: DashboardNote): DashboardNote {
+  const createdTime = new Date(note.created).getTime();
+  const updatedTime = note.updated ? new Date(note.updated).getTime() : null;
+
+  if (updatedTime !== null && updatedTime - createdTime <= UPDATED_BUFFER_MS) {
+    return { ...note, updated: null };
+  }
+  return note;
 }
 
 export function useNotes() {
-  const notes = ref<DashboardNote[] | null>(null);
+  const rawNotes = ref<DashboardNote[] | null>(null);
 
-  const notesQuery = useGet2("api/org/query/notes/", notes);
+  const notesQuery = useGet2("api/org/query/notes/", rawNotes);
+
+  const notes = computed(() => rawNotes.value?.map(resetUpdatedDate) ?? null);
 
   return {
     notesQuery,

--- a/src/features/dashboard/components/NotesList.vue
+++ b/src/features/dashboard/components/NotesList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { CalendarIcon } from "@heroicons/vue/24/outline";
 import { computed } from "vue";
 
 import BoxLoader from "@/components/BoxLoader.vue";
@@ -8,6 +9,7 @@ import DeleteNote from "@/features/dashboard/actions/DeleteNote.vue";
 import UpdateNote from "@/features/dashboard/actions/UpdateNote.vue";
 import { useNotes } from "@/features/dashboard/api/useNotes";
 import { useUserStore } from "@/store/user";
+import { formatDate } from "@/utils/date";
 
 const userStore = useUserStore();
 const { notes, notesQuery } = useNotes();
@@ -30,6 +32,13 @@ const canManageNotes = computed(() =>
           class="hover:border-formcolor/20 rounded-lg border border-gray-200 bg-white p-4 transition-all duration-200 hover:shadow-md"
           :class="{ 'lg:col-span-2': note.is_wide }"
         >
+          <div class="mb-2 flex items-center text-xs text-gray-500">
+            <CalendarIcon class="mr-1 h-3 w-3" />
+            <span>Created: {{ formatDate(note.created) }}</span>
+            <span v-if="note.updated"
+              >, updated {{ formatDate(note.updated) }}</span
+            >
+          </div>
           <div class="flex justify-between">
             <h3 class="mb-2 flex items-center gap-2 font-medium text-gray-700">
               {{ note.title }}


### PR DESCRIPTION
### Short Description
<!-- Describe this PR in one or two sentences. -->
This PR adds the created and updated fields to notes. One workaround I had to build is to compare updated and created to each other and if it doesn't exceed a buffer, set updated to null. Please make sure to checkout this branch [in the backend](https://github.com/lawandorga/lawandorga-backend-service/pull/657) to test this.

### Proposed Changes
<!-- Describe this PR in more detail. -->

- Add created and updated to notes
- Set updated to null, if it's only slightly newer than created (thus probably has been updated during creation)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None are intended

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #656 
